### PR TITLE
INT-282 return whole files in changes

### DIFF
--- a/src/buildChangeMessages.ts
+++ b/src/buildChangeMessages.ts
@@ -1,51 +1,21 @@
-import { diffChars } from 'diff';
 import { CodemodId } from './codemods';
 import { ChangeMessage, MessageKind } from './messages';
 
-const isTextRelevant = (text: string): boolean => {
-	return text.replace(/ /gm, '').replace(/\n/gm, '').length !== 0;
-};
-
-export const buildChangeMessages = (
+export const buildChangeMessage = (
 	filePath: string,
 	oldSource: string,
 	newSource: string,
 	codemodId: CodemodId,
-): ReadonlyArray<ChangeMessage> => {
-	const diffChanges = diffChars(oldSource, newSource);
-
-	const changes: ChangeMessage[] = [];
-	let leftCount = 0;
-
-	for (const diffChange of diffChanges) {
-		const count = diffChange.count ?? 0;
-
-		if (diffChange.added && isTextRelevant(diffChange.value)) {
-			const range: ChangeMessage['r'] = [leftCount, leftCount];
-
-			changes.push({
-				k: MessageKind.change,
-				p: filePath,
-				r: range,
-				t: diffChange.value,
-				c: codemodId,
-			});
-		} else if (diffChange.removed && isTextRelevant(diffChange.value)) {
-			const range: ChangeMessage['r'] = [leftCount, leftCount + count];
-
-			changes.push({
-				k: MessageKind.change,
-				p: filePath,
-				r: range,
-				t: diffChange.value,
-				c: codemodId,
-			});
-
-			leftCount += count;
-		} else {
-			leftCount += count;
-		}
+): ChangeMessage | null => {
+	if (oldSource === newSource) {
+		return null;
 	}
 
-	return changes;
+	return {
+		k: MessageKind.change,
+		p: filePath,
+		r: [0, oldSource.length],
+		t: newSource,
+		c: codemodId,
+	};
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { hideBin } from 'yargs/helpers';
 import fastGlob from 'fast-glob';
 import jscodeshift, { API, FileInfo } from 'jscodeshift';
 import { readFileSync } from 'fs';
-import { buildChangeMessages } from './buildChangeMessages';
+import { buildChangeMessage } from './buildChangeMessages';
 import { FinishMessage, MessageKind } from './messages';
 import { codemods } from './codemods';
 
@@ -52,14 +52,14 @@ argv.then(async ({ pattern }) => {
 
 				const newSource = codemod.transformer(fileInfo, api);
 
-				const changes = buildChangeMessages(
+				const change = buildChangeMessage(
 					String(filePath),
 					oldSource,
 					newSource,
 					codemod.id,
 				);
 
-				for (const change of changes) {
+				if (change) {
 					console.log(JSON.stringify(change));
 				}
 			}


### PR DESCRIPTION
JSCodeShift formats code in the way that it is virtually impossible to create correct diffs. We will return whole files for now in changes.